### PR TITLE
Add nix flake w/ derivation and example

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+watch_file flake.nix
+watch_file flake.lock
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ go.work
 build/
 
 dist/
+
+# Direnv
+.direnv/
+
+# Nix build symlink
+result

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ TLock is an open-source tool to store and manage your authentication tokens secu
   ```
 
 - **NixOS** (with Flakes)
+
+  Try out before installing ✨
+  ```fish
+  nix run "git+https://github.com/eklairs/tlock?submodules=1"
+  ```
+
+  Minimal configuration:
   ```nix
   # flake.nix
   {

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ TLock is an open-source tool to store and manage your authentication tokens secu
   {
     inputs = {
       nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-      tlock.url = "github:eklairs/tlock";
+      tlock.url = "git+https://github.com/eklairs/tlock?submodules=1";
       tlock.inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,37 @@ TLock is an open-source tool to store and manage your authentication tokens secu
   yay -S tlock
   ```
 
+- **NixOS** (with Flakes)
+  ```nix
+  # flake.nix
+  {
+    inputs = {
+      nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+      tlock.url = "github:eklairs/tlock";
+      tlock.inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    outputs = inputs @ { self, nixpkgs, tlock, ... }:
+    {
+      # Change hostname etc. as needed
+      nixosConfigurations.hostname = let
+        system = "x86_64-linux";
+        lib = nixpkgs.lib;
+      in lib.nixosSystem {
+        inherit system;
+        modules = [
+          {
+            environment.systemPackages = [
+              tlock.packages.${system}.default
+            ];
+          }
+          ./configuration.nix
+        ];
+      };
+    };
+  }
+  ```
+
 - **Windows** (with scoop)
 
   ```fish

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1714641030,
+        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1715534503,
+        "narHash": "sha256-5ZSVkFadZbFP1THataCaSf0JH2cAH3S29hU9rrxTEqk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2057814051972fa1453ddfb0d98badbea9b83c06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1714640452,
+        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,12 +11,15 @@
     perSystem = { system, ... }: let
       pkgs = import nixpkgs { inherit system; };
       git_version = self.shortRev or self.dirtyShortRev;
-    in {
+    in rec {
       packages = rec {
         tlock = pkgs.callPackage ./nix { inherit git_version; };
         default = tlock;
       };
+
+      devShells.default = pkgs.mkShell {
+        inputsFrom = [ packages.default ];
+      };
     };
   };
 }
-

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs @ { self, nixpkgs, flake-parts, ... }:
+  flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = [ "x86_64-linux" ];
+
+    perSystem = { system, ... }: let
+      pkgs = import nixpkgs { inherit system; };
+      git_version = self.shortRev or self.dirtyShortRev;
+    in {
+      packages = rec {
+        tlock = pkgs.callPackage ./nix { inherit git_version; };
+        default = tlock;
+      };
+    };
+  };
+}
+

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 echo "=> gofmt-ing staged files"
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,8 +1,7 @@
-{ pkgs, lib, buildGoModule, git_version, ... }: let
-  manifest = builtins.fromJSON (builtins.readFile (../. + "/tlock.json"));
-in buildGoModule rec {
+{ pkgs, lib, buildGoModule, git_version, ... }:
+buildGoModule rec {
   pname = "tlock";
-  version = manifest.version;
+  version = "1.0.0";
 
   src = lib.cleanSource ../.;
   vendorHash = "sha256-G402CigSvloF/SI9Wbcts/So1impMUH5kroxDD/KKew=";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,21 @@
+{ pkgs, lib, buildGoModule, git_version, ... }: let
+  manifest = builtins.fromJSON (builtins.readFile (../. + "/tlock.json"));
+in buildGoModule rec {
+  pname = "tlock";
+  version = manifest.version;
+
+  src = lib.cleanSource ../.;
+  vendorHash = "sha256-G402CigSvloF/SI9Wbcts/So1impMUH5kroxDD/KKew=";
+
+  ldflags = [
+    "-X github.com/eklairs/tlock/tlock-internal/constants.VERSION=v${version}-${git_version}"
+  ];
+
+  excludedPackages = [ "bubbletea" ];
+  
+  meta = with lib; {
+    description = "Two-Factor Authentication Tokens Manager in Terminal";
+    homepage = "https://github.com/eklairs/tlock";
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
:wave: I was curious to try out the project, but noticed that there is no derivation to build it with Nix.

The PR adds a flake and derivation, and I also included a minimal example in the README.
This way the Github repo can be referenced directly, but you should also be able to reuse the package output if you want to add it to nixpkgs -> #2