### PR TITLE
fix: Use `grim` to take screenshots on wayland (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ TLock is an open-source tool to store and manage your authentication tokens secu
 >[!NOTE]
 >For showing the provider's icon, you must have Nerd Fonts installed
 
+>[!NOTE]
+>To make screenshot feature work on wayland, you need to install grim
+
 ## ⬇️ Installation
 
 - **Arch Linux** (with AUR helper, like yay)

--- a/tlock-internal/utils/read_screen.go
+++ b/tlock-internal/utils/read_screen.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/kbinani/screenshot"
+	"github.com/makiuchi-d/gozxing"
+	"github.com/makiuchi-d/gozxing/qrcode"
+)
+
+// Returns if the current session is wayland
+func isWayland() bool {
+	return os.Getenv("XDG_SESSION_TYPE") == "wayland"
+}
+
+// Error when no token on the screen is found
+var TOKEN_NOT_FOUND_ERR = errors.New("No token found on the screen")
+
+// Reads QRCode from screen and returns the found data (not for wayland)
+func ReadTokenFromScreenNoWayland() (*string, error) {
+	// Capture rect
+	image, err := screenshot.CaptureRect(screenshot.GetDisplayBounds(0))
+	if err != nil {
+		return nil, err
+	}
+
+	// Create bitmap
+	bmp, err := gozxing.NewBinaryBitmapFromImage(image)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create reader
+	qrReader := qrcode.NewQRCodeReader()
+
+	// Decode
+	if result, err := qrReader.Decode(bmp, nil); err == nil {
+		// Get fetched URI
+		uri := result.String()
+
+		// Return
+		return &uri, nil
+	}
+
+	// No token found
+	return nil, TOKEN_NOT_FOUND_ERR
+}
+
+// Reads QRCode form screen and returns the found data (only for wayland)
+func ReadTokenFromScreenWaylandOnly() (*string, error) {
+	// Make grim command
+	_, err := exec.Command("grim").Output()
+
+	// Check for error
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Cannot run grim command: %s", err))
+	}
+
+	return nil, nil
+}
+
+// Reads QRCode from screen based on the session type
+func ReadTokenFromScreen() (*string, error) {
+	// Check if it is wayland
+	if isWayland() {
+		return ReadTokenFromScreenWaylandOnly()
+	}
+
+	// Use normal function
+	return ReadTokenFromScreenNoWayland()
+}

--- a/tlock-internal/utils/read_screen.go
+++ b/tlock-internal/utils/read_screen.go
@@ -3,30 +3,42 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"image"
 	"os"
 	"os/exec"
+
+	_ "image/png"
 
 	"github.com/kbinani/screenshot"
 	"github.com/makiuchi-d/gozxing"
 	"github.com/makiuchi-d/gozxing/qrcode"
 )
 
+// Loads an image from file
+func getImageFromFilePath(filePath string) (image.Image, error) {
+	// Read file path
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Close on scope end
+	defer f.Close()
+
+	// Decode
+	image, _, err := image.Decode(f)
+
+	// Return
+	return image, err
+}
+
 // Returns if the current session is wayland
 func isWayland() bool {
 	return os.Getenv("XDG_SESSION_TYPE") == "wayland"
 }
 
-// Error when no token on the screen is found
-var TOKEN_NOT_FOUND_ERR = errors.New("No token found on the screen")
-
-// Reads QRCode from screen and returns the found data (not for wayland)
-func ReadTokenFromScreenNoWayland() (*string, error) {
-	// Capture rect
-	image, err := screenshot.CaptureRect(screenshot.GetDisplayBounds(0))
-	if err != nil {
-		return nil, err
-	}
-
+// Reads the QRCode from the image
+func readFromImage(image image.Image) (*string, error) {
 	// Create bitmap
 	bmp, err := gozxing.NewBinaryBitmapFromImage(image)
 	if err != nil {
@@ -47,19 +59,43 @@ func ReadTokenFromScreenNoWayland() (*string, error) {
 
 	// No token found
 	return nil, TOKEN_NOT_FOUND_ERR
+
+}
+
+// Error when no token on the screen is found
+var TOKEN_NOT_FOUND_ERR = errors.New("No token found on the screen")
+
+// Reads QRCode from screen and returns the found data (not for wayland)
+func ReadTokenFromScreenNoWayland() (*string, error) {
+	// Capture rect
+	image, err := screenshot.CaptureRect(screenshot.GetDisplayBounds(0))
+	if err != nil {
+		return nil, err
+	}
+
+	// Return
+	return readFromImage(image)
 }
 
 // Reads QRCode form screen and returns the found data (only for wayland)
 func ReadTokenFromScreenWaylandOnly() (*string, error) {
-	// Make grim command
-	_, err := exec.Command("grim").Output()
+	// Out path
+	out := "/tmp/tlock_screenshot.png"
 
-	// Check for error
+	// Make grim command
+	_, err := exec.Command("grim", out).Output()
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Cannot run grim command: %s", err))
 	}
 
-	return nil, TOKEN_NOT_FOUND_ERR
+	// Load screenshot
+	image, err := getImageFromFilePath(out)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read
+	return readFromImage(image)
 }
 
 // Reads QRCode from screen based on the session type

--- a/tlock-internal/utils/read_screen.go
+++ b/tlock-internal/utils/read_screen.go
@@ -59,7 +59,7 @@ func ReadTokenFromScreenWaylandOnly() (*string, error) {
 		return nil, errors.New(fmt.Sprintf("Cannot run grim command: %s", err))
 	}
 
-	return nil, nil
+	return nil, TOKEN_NOT_FOUND_ERR
 }
 
 // Reads QRCode from screen based on the session type

--- a/tlock/models/dashboard/tokens/from_screen.go
+++ b/tlock/models/dashboard/tokens/from_screen.go
@@ -207,10 +207,10 @@ func (screen TokenFromScreen) Update(msg tea.Msg, manager *modelmanager.ModelMan
 							dataScreen.Err = err
 						}
 					}
-
-					// Send
-					dataFromScreenChan <- &dataScreen
 				}
+
+				// Send
+				dataFromScreenChan <- &dataScreen
 			}()
 
 		case key.Matches(msgType, confirmScreenKeys.Retake):

--- a/tlock/models/dashboard/tokens/from_screen.go
+++ b/tlock/models/dashboard/tokens/from_screen.go
@@ -2,7 +2,6 @@ package tokens
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -267,9 +266,7 @@ func (screen TokenFromScreen) View() string {
 		}
 
 		// If the token is null, show the message
-		if screen.token == nil {
-			items = append(items, tlockstyles.Styles.Error.Render("Did not find any token!"))
-		} else {
+		if screen.token != nil {
 			// Try to parse the otp value
 			if screen.token.Err == nil {
 				key, err := otp.NewKeyFromURL(*screen.token.Uri)
@@ -297,8 +294,7 @@ func (screen TokenFromScreen) View() string {
 			} else {
 				items = append(items, lipgloss.JoinHorizontal(
 					lipgloss.Center,
-					tlockstyles.Styles.Base.Render("Found a token from screen, but "),
-					tlockstyles.Styles.Error.Render(strings.ToLower(screen.token.Err.Error())),
+					tlockstyles.Styles.Error.Render(screen.token.Err.Error()),
 				))
 			}
 		}


### PR DESCRIPTION
The go `screenshot` library cannot take screenshots on wayland, which returns "No token found" even if there is a token on the screen.

This PR creates another function to read token from screen for wayland sessions using `grim`.

Closes #6  